### PR TITLE
Update gdb.config

### DIFF
--- a/gdb.config
+++ b/gdb.config
@@ -6,26 +6,26 @@
 #Homo sapiens    idmapper-pgdb:/home/martijn/PathVisio-Data/gene databases/Hs_Derby_20090509.pgdb
 #Mus musculus    idmapper-pgdb:/home/martijn/PathVisio-Data/gene databases/Mm_Derby_20081119.pgdb
 
-Homo sapiens    /opt/bridgedb-databases/bridgedb.org/data/gene_database/Hs_Derby_85.bridge
-Mus musculus    /opt/bridgedb-databases/bridgedb.org/data/gene_database/Mm_Derby_85.bridge
-Rattus norvegicus       /opt/bridgedb-databases/bridgedb.org/data/gene_database/Rn_Derby_85.bridge
-Danio rerio     /opt/bridgedb-databases/bridgedb.org/data/gene_database/Dr_Derby_85.bridge
-Caenorhabditis elegans  /opt/bridgedb-databases/bridgedb.org/data/gene_database/Ce_Derby_85.bridge
-Saccharomyces cerevisiae        /opt/bridgedb-databases/bridgedb.org/data/gene_database/Sc_Derby_85.bridge
-Drosophila melanogaster /opt/bridgedb-databases/bridgedb.org/data/gene_database/Dm_Derby_85.bridge
-Anopheles gambiae       /opt/bridgedb-databases/bridgedb.org/data/gene_database/Ag_Derby_85.bridge
-Arabidopsis thaliana    /opt/bridgedb-databases/bridgedb.org/data/gene_database/At_Derby_85.bridge
-Bos taurus      /opt/bridgedb-databases/bridgedb.org/data/gene_database/Bt_Derby_85.bridge
-Bacillus subtilis       /opt/bridgedb-databases/bridgedb.org/data/gene_database/Bs_Derby_85.bridge
-Canis familiaris        /opt/bridgedb-databases/bridgedb.org/data/gene_database/Cf_Derby_85.bridge
-Equus caballus  /opt/bridgedb-databases/bridgedb.org/data/gene_database/Qc_Derby_85.bridge
-Gallus gallus   /opt/bridgedb-databases/bridgedb.org/data/gene_database/Gg_Derby_85.bridge
-Mycobacterium tuberculosis      /opt/bridgedb-databases/bridgedb.org/data/gene_database/Mx_Derby_85.bridge
-Oryza sativa    /opt/bridgedb-databases/bridgedb.org/data/gene_database/Oj_Derby_85.bridge
-Pan troglodytes /opt/bridgedb-databases/bridgedb.org/data/gene_database/Pt_Derby_85.bridge
-Sus scrofa      /opt/bridgedb-databases/bridgedb.org/data/gene_database/Ss_Derby_85.bridge
-Zea mays        /opt/bridgedb-databases/bridgedb.org/data/gene_database/Zm_Derby_85.bridge
-*       /opt/bridgedb-databases/bridgedb.org/data/gene_database/metabolites_100227.bridge
+Homo sapiens    /opt/bridgedb-databases/bridgedb.org/data/gene_database/Hs_Derby_Ensembl_85.bridge
+Mus musculus    /opt/bridgedb-databases/bridgedb.org/data/gene_database/Mm_Derby_Ensembl_85.bridge
+Rattus norvegicus       /opt/bridgedb-databases/bridgedb.org/data/gene_database/Rn_Derby_Ensembl_85.bridge
+Danio rerio     /opt/bridgedb-databases/bridgedb.org/data/gene_database/Dr_Derby_Ensembl_85.bridge
+Caenorhabditis elegans  /opt/bridgedb-databases/bridgedb.org/data/gene_database/Ce_Derby_Ensembl_85.bridge
+Saccharomyces cerevisiae        /opt/bridgedb-databases/bridgedb.org/data/gene_database/Sc_Derby_Ensembl_85.bridge
+Drosophila melanogaster /opt/bridgedb-databases/bridgedb.org/data/gene_database/Dm_Derby_Ensembl_85.bridge
+Anopheles gambiae       /opt/bridgedb-databases/bridgedb.org/data/gene_database/Ag_Derby_Ensembl_85.bridge
+Arabidopsis thaliana    /opt/bridgedb-databases/bridgedb.org/data/gene_database/At_Derby_Ensembl_85.bridge
+Bos taurus      /opt/bridgedb-databases/bridgedb.org/data/gene_database/Bt_Derby_Ensembl_85.bridge
+Bacillus subtilis       /opt/bridgedb-databases/bridgedb.org/data/gene_database/Bs_Derby_Ensembl_85.bridge
+Canis familiaris        /opt/bridgedb-databases/bridgedb.org/data/gene_database/Cf_Derby_Ensembl_85.bridge
+Equus caballus  /opt/bridgedb-databases/bridgedb.org/data/gene_database/Qc_Derby_Ensembl_85.bridge
+Gallus gallus   /opt/bridgedb-databases/bridgedb.org/data/gene_database/Gg_Derby_Ensembl_85.bridge
+Mycobacterium tuberculosis      /opt/bridgedb-databases/bridgedb.org/data/gene_database/Mx_Derby_Ensembl_85.bridge
+Oryza sativa    /opt/bridgedb-databases/bridgedb.org/data/gene_database/Oj_Derby_Ensembl_85.bridge
+Pan troglodytes /opt/bridgedb-databases/bridgedb.org/data/gene_database/Pt_Derby_Ensembl_85.bridge
+Sus scrofa      /opt/bridgedb-databases/bridgedb.org/data/gene_database/Ss_Derby_Ensembl_85.bridge
+Zea mays        /opt/bridgedb-databases/bridgedb.org/data/gene_database/Zm_Derby_Ensembl_85.bridge
+*       /opt/bridgedb-databases/bridgedb.org/data/gene_database/metabolites_20170826.bridge
 
 # Databases configured with an asterisk instead of the species name
 # Will be mixed in for each species


### PR DESCRIPTION
The file links in this did not correspond to the ones that can be found on http://bridgedb.org/data/gene_database/  
I think this is necessary to parse the gene database configuration