### PR TITLE
Adds the repository_dispatch trigger

### DIFF
--- a/.github/workflows/buildandpush.yml
+++ b/.github/workflows/buildandpush.yml
@@ -1,6 +1,8 @@
 name: Docker build
 
 on:
+  repository_dispatch:
+    types: [update-event]
   workflow_dispatch:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
This trigger allows the workflow to be triggered with a webhook event `update-event` sent from a workflow in another repository, bridgedb/data. @egonw 

It's working on my forks (see https://github.com/jmillanacosta/docker/actions/runs/4134958331)

After merging this PR, merge the latest PR in bridgedb/data and store a `PAT` with `repo` scopes named `pat_external_workflow` in the repository bridgedb/data