### PR TITLE
fixes sed regular expression to update BDBWS version in setup.sh

### DIFF
--- a/.github/workflows/buildandpush.yml
+++ b/.github/workflows/buildandpush.yml
@@ -45,7 +45,7 @@ jobs:
         name: Retrieve WebService version name
         run: |
             wget https://raw.githubusercontent.com/bridgedb/BridgeDbWebservice/main/pom.xml
-            echo "BDBWSVERSION=$(cat pom.xml | grep -m 1 -oP "(?<=<version>).*" | sed 's|</version>||g')" >> $GITHUB_ENV 
+            echo "BRIDGEDBWSVERSION=$(cat pom.xml | grep -m 1 -oP "(?<=<version>).*" | sed 's|</version>||g')" >> $GITHUB_ENV 
             
       - name: Update setup.sh with BDBWSVERSION
         run: |

--- a/.github/workflows/buildandpush.yml
+++ b/.github/workflows/buildandpush.yml
@@ -49,7 +49,7 @@ jobs:
             
       - name: Update setup.sh with BDBWSVERSION
         run: |
-            cat setup.sh | sed 's|BDBVERSION=".\+"|BRIDGEDBVERSION="${{ env.BDBWSVERSION }}"|g' > setup.sh
+            cat setup.sh | sed 's|BRIDGEDBWSVERSION=".\+"|BRIDGEDBVERSION="${{ env.BDBWSVERSION }}"|g' > setup.sh
       
 #      - name: Echo new BDBVERSION (debug)
 #        run: |

--- a/.github/workflows/buildandpush.yml
+++ b/.github/workflows/buildandpush.yml
@@ -49,7 +49,7 @@ jobs:
             
       - name: Update setup.sh with BDBWSVERSION
         run: |
-            cat setup.sh | sed 's|BRIDGEDBWSVERSION=".\+"|BRIDGEDBVERSION="${{ env.BDBWSVERSION }}"|g' > setup.sh
+            cat setup.sh | sed 's|BRIDGEDBWSVERSION=".\+"|BRIDGEDBWSVERSION="${{ env.BRIDGEDBWSVERSION }}"|g'  > setup.sh
       
 #      - name: Echo new BDBVERSION (debug)
 #        run: |

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,11 @@
 #apt-get -y install wget
 #apt-get -y install zip unzip
 #whoami
+
+#IMPORTANT
+#This line is updated at every run of https://github.com/bridgedb/docker/blob/master/.github/workflows/buildandpush.yml substituting the
+#bridgedbwsversion with the one declared in the bridgedbwservice pom (https://raw.githubusercontent.com/bridgedb/BridgeDbWebservice/main/pom.xml).
+#The changes are NOT committed and pushed, but are effective when running setup.sh in the action.
 export BRIDGEDBWSVERSION="2.1.4"
 
 cd /opt/


### PR DESCRIPTION
Coming from here: https://github.com/VHP4Safety/cloud/issues/42#issuecomment-1591015450

I don't remember why I wrote 
```bash
sed 's|BDBVERSION=".\+"|BRIDGEDBVERSION="${{ env.BDBWSVERSION }}"|g'
```
instead of 
```bash
sed 's|BRIDGEDBWSVERSION=".\+"|BRIDGEDBVERSION="${{ env.BDBWSVERSION }}"|g'
```
but of course that led to the sed command not being able to perform the substitution thus it kept the previously hardcoded version of bdbws in the `setup.sh` file.


@egonw @ozancinar do you think this was the root of the error?