### PR TITLE
Add docker job, retrieve version tags before build

### DIFF
--- a/.github/workflows/buildandpush.yml
+++ b/.github/workflows/buildandpush.yml
@@ -7,18 +7,18 @@ on:
   push:
     branches: [ "master" ]
     paths:
-     - 'setup.sh'
+     #- 'setup.sh'
      - 'startup.sh'
      - 'Dockerfile'
   pull_request:
     branches: [ "master" ]
     paths:
-     - 'setup.sh'
+     #- 'setup.sh'
      - 'startup.sh'
      - 'Dockerfile'
 
 jobs:
-  docker:
+  update-version:
     runs-on: ubuntu-latest
     steps:
       -
@@ -51,18 +51,29 @@ jobs:
         run: |
             cat setup.sh | sed 's|BRIDGEDBWSVERSION=".\+"|BRIDGEDBWSVERSION="${{ env.BRIDGEDBWSVERSION }}"|g'  > setup.sh
       
-#      - name: Echo new BDBVERSION (debug)
-#        run: |
-#  
-#            echo New release tag: ${{ env.BDBWSVERSION }}
-                      
+      - name: commit and push setup.sh # Test whether it is necessary to push before the docker action accesses repository from git context
+        run: |
+            git add setup.sh
+            git commit -m "Updated setup.sh with ${{ env.BDBVERSION }}-${{ env.BRIDGEDBWSVERSION }}"
+            git push
+  
+            echo New release tag: ${{ env.BDBWSVERSION }}
+  docker:
+    runs-on: ubuntu-latest
+    steps:  
+      -
+        name: Retrieve tags
+        run: |
+          wget https://raw.githubusercontent.com/bridgedb/BridgeDbWebservice/main/pom.xml
+          echo "BDBVERSION=$(cat pom.xml | grep -m 1 -oP "(?<=<bridgedb-version>).*" | sed 's|</bridgedb-version>||g')" >> $GITHUB_ENV 
+          wget https://raw.githubusercontent.com/bridgedb/BridgeDbWebservice/main/pom.xml
+          echo "BRIDGEDBWSVERSION=$(cat pom.xml | grep -m 1 -oP "(?<=<version>).*" | sed 's|</version>||g')" >> $GITHUB_ENV 
       -
         name: Build and push
         uses: docker/build-push-action@v4
         with:
           push: true
           tags: bigcatum/bridgedb:${{ env.BDBVERSION }}-${{ env.BRIDGEDBWSVERSION }}
-
       -
         name: Build and push
         uses: docker/build-push-action@v4


### PR DESCRIPTION
Environment variables are lost between jobs, so the docker job retrieves them again.
The docker action is put in a separate job after a job that updates the setup.sh file with the new BDB and BDBWS versions and pushes to the repository.