### PR TITLE
bumped Node.js 16 actions to Node.js 20 versions

### DIFF
--- a/.github/workflows/buildandpush.yml
+++ b/.github/workflows/buildandpush.yml
@@ -63,13 +63,13 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
           echo "BRIDGEDBWSVERSION=$(cat pom.xml | grep -m 1 -oP "(?<=<version>).*" | sed 's|</version>||g')" >> $GITHUB_ENV 
       -
         name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: bigcatum/bridgedb:${{ env.BDBVERSION }}-${{ env.BRIDGEDBWSVERSION }}


### PR DESCRIPTION
Prevent warning
```
docker
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: docker/setup-qemu-action@v2, docker/setup-buildx-action@v2, docker/login-action@v2, docker/build-push-action@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

(see https://github.com/bridgedb/docker/actions/runs/8922939221)